### PR TITLE
When connecting to an upstream fails, raise HTTP 503

### DIFF
--- a/src/main/java/eu/xenit/alfred/content/gateway/GatewayApplication.java
+++ b/src/main/java/eu/xenit/alfred/content/gateway/GatewayApplication.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import eu.xenit.alfred.content.gateway.cors.CorsConfigurationResolver;
 import eu.xenit.alfred.content.gateway.cors.CorsResolverProperties;
+import eu.xenit.alfred.content.gateway.error.ProxyUpstreamUnavailableWebFilter;
 import eu.xenit.contentcloud.opa.client.OpaClient;
 import eu.xenit.contentcloud.opa.client.rest.RestClientConfiguration.LogSpecification;
 import eu.xenit.contentcloud.thunx.pdp.PolicyDecisionComponentImpl;
@@ -39,6 +40,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.properties.bind.Bindable;
 import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
@@ -223,6 +225,11 @@ public class GatewayApplication {
     @Bean
     public AbacGatewayFilterFactory abacGatewayFilterFactory() {
         return new AbacGatewayFilterFactory();
+    }
+
+    @Bean
+    public GlobalFilter proxyUpstreamUnavailableWebFilter()  {
+        return new ProxyUpstreamUnavailableWebFilter();
     }
 
     private static class OAuth2ClientRegistrationsGuard {

--- a/src/main/java/eu/xenit/alfred/content/gateway/error/ProxyUpstreamUnavailableWebFilter.java
+++ b/src/main/java/eu/xenit/alfred/content/gateway/error/ProxyUpstreamUnavailableWebFilter.java
@@ -1,0 +1,40 @@
+package eu.xenit.alfred.content.gateway.error;
+
+import java.net.SocketException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.cloud.gateway.filter.NettyRoutingFilter;
+import org.springframework.cloud.gateway.support.ServerWebExchangeUtils;
+import org.springframework.cloud.gateway.support.ServiceUnavailableException;
+import org.springframework.core.Ordered;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+public class ProxyUpstreamUnavailableWebFilter implements GlobalFilter, Ordered {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        Mono<Void> completion;
+        try {
+            completion = chain.filter(exchange);
+        } catch(Exception e) {
+            completion = Mono.error(e);
+        }
+
+        return completion.onErrorMap(SocketException.class, e -> {
+            var newException = new ServiceUnavailableException(e.getMessage());
+            newException.initCause(e);
+            var request = exchange.getRequest();
+            var routeName = exchange.getAttributeOrDefault(ServerWebExchangeUtils.GATEWAY_PREDICATE_MATCHED_PATH_ROUTE_ID_ATTR, "null");
+            log.error(String.format("Upstream service '%s' unavailable: '%s %s' failed", routeName, request.getMethodValue(), request.getURI().toASCIIString()), e);
+            return newException;
+        }).checkpoint();
+    }
+
+    @Override
+    public int getOrder() {
+        return NettyRoutingFilter.ORDER-1;
+    }
+}


### PR DESCRIPTION
Instead of throwing a HTTP 500 internal server error when an upstream service fails,
raise the more correct HTTP 503 service unavailable
